### PR TITLE
Pathfield Granite UI component: Add support for nodeTypes filtering

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,6 +25,9 @@
 
     <release version="1.9.0" date="not released">
       <action type="update" dev="sseifert">
+        Pathfield Granite UI component: Add support for nodeTypes filtering, and default to cq:Page or dam:Asset (depending on rootPath).
+      </action>
+      <action type="update" dev="sseifert">
         Switch to AEM 6.5 as minimum version.
       </action>
     </release>

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
@@ -62,7 +62,6 @@ import com.adobe.granite.ui.components.ds.EmptyDataSource;
 import com.day.cq.commons.predicate.PredicateProvider;
 
 import io.wcm.wcm.ui.granite.pathfield.impl.predicate.HideInternalContentPathsPredicate;
-import io.wcm.wcm.ui.granite.pathfield.impl.util.DummyPageContext;
 import io.wcm.wcm.ui.granite.pathfield.impl.util.PredicatedResourceWrapper;
 
 /**
@@ -88,7 +87,7 @@ public class PathFieldChildrenDatasourceServlet extends SlingSafeMethodsServlet 
   protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
       throws ServletException, IOException {
 
-    final ExpressionHelper ex = new ExpressionHelper(expressionResolver, new DummyPageContext(request, response));
+    final ExpressionHelper ex = new ExpressionHelper(expressionResolver, request);
     final Config cfg = new Config(request.getResource().getChild(Config.DATASOURCE));
 
     final String query = ex.getString(cfg.get("query", String.class));

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/util/DummyPageContext.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/util/DummyPageContext.java
@@ -39,8 +39,8 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 
 /**
- * Workaround because {@link com.adobe.granite.ui.components.ExpressionHelper} supports
- * no direct pass-in of SlingHttpServletRequest in AEM 6.2 API (this was fixed in AEM 6.3 API).
+ * Workaround because {@link com.adobe.granite.ui.components.ComponentHelper} supports
+ * no direct pass-in of SlingHttpServletRequest.
  */
 @SuppressWarnings("deprecation")
 public class DummyPageContext extends PageContext {

--- a/src/main/webapp/app-root/content/form/pathfield/picker.json
+++ b/src/main/webapp/app-root/content/form/pathfield/picker.json
@@ -1,7 +1,9 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "rootPath": "${empty param.root ? \"/\" : param.root}",
+  "searchFormContainsNodeTypes": false,
   "path": "${empty param.path ? (empty param.root ? \"/\" : param.root) : param.path}",
+  "nodeTypes": "${empty param.nodeTypes ? \"\" : param.nodeTypes}",
   "sling:resourceType": "wcm-io/wcm/ui/granite/components/form/pathfield/picker",
   "targetCollection": "#granite-ui-pathfield-picker-collection",
   "selectionCount": "${empty param.selectionCount ? \"single\" : param.selectionCount}",
@@ -33,26 +35,16 @@
     "name": "fulltext",
     "targetCollection": "#granite-ui-pathfield-picker-search-collection",
     "form": {
+      "excludepaths": {
+        "name": "excludepaths",
+        "value": "(.*)?(jcr:content|rep:policy)(/.*)?",
+        "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden"
+      },
       "rootpath": {
         "name": "path",
         "value": "${empty param.root ? \"/\" : param.root}",
         "fieldLabel": "Path",
         "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield"
-      },
-      "group_or": {
-        "name": "group.p.or",
-        "value": "true",
-        "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden"
-      },
-      "group_1_type": {
-        "name": "group.1_type",
-        "value": "cq:Page",
-        "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden"
-      },
-      "group_2_type": {
-        "name": "group.2_type",
-        "value": "dam:Asset",
-        "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden"
       },
       "orderby": {
         "name": "orderby",
@@ -83,7 +75,7 @@
         "selectionCount": "${requestPathInfo.selectors[1]}",
         "datasource": {
           "offset": "${requestPathInfo.selectors[2]}",
-          "itemResourceType": "cq/gui/components/coral/admin/page/card",
+          "itemResourceType": "granite/ui/components/coral/foundation/form/pathfield/card",
           "limit": "${empty requestPathInfo.selectors[3] ? \"21\" : requestPathInfo.selectors[3] + 1}",
           "sling:resourceType": "granite/ui/components/coral/foundation/querybuilder/datasource"
         }

--- a/src/site/markdown/components.md
+++ b/src/site/markdown/components.md
@@ -78,8 +78,6 @@ Enhancements over AEM version:
 
 ![Path Field component](images/pathfield-component.png)
 
-*Please note:* Some of the listed features will only work in AEM 6.3 and higher.
-
 A field that allows the user to enter path. This path field can be used for both picking page paths or asset paths.
 
 ```json
@@ -99,6 +97,7 @@ Enhancements over AEM version:
 * Hides certain "AEM-internal" content paths which should not be shown when picking pages or assets
 * Provide `appendPath` parameter that allows to add an additional sub path to the configured root path
 * Supports any resource-based predicates as `filter` (and not only `folder`, `hierarchy`, `hierarchyNotFile`, `nosystem`)
+* Automatically applies a `nodeTypes` filter when none is configured (cq:Page or dam:Asset, depending on root path)
 
 
 ### Config-Scope Path Browser (deprecated)


### PR DESCRIPTION
and default to cq:Page or dam:Asset (depending on rootPath).
remove fallback to pathbrowser