### PR TITLE
WWCM-19 Replace "=" with "~=" to allow partial matching of the data-(…

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.9.8" date="not released">
+      <action type="update" dev="henrykuijpers">
+        Granite UI validators: Allow to apply multiple validators by changing selector to '~='.
+      </action>
+    </release>
+
     <release version="1.9.6" date="2022-06-22">
       <action type="fix" dev="sseifert">
         Pathfield Granite UI component: Fix selection problem when opening pathfield component first time. Sync with latest changes with AEM pathfield component.

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.validation/js/validation.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.validation/js/validation.js
@@ -45,7 +45,7 @@
 
   // predefined "email" pattern validator
   registry.register('foundation.validation.validator', {
-    selector: '[data-foundation-validation="wcmio.email"]',
+    selector: '[data-foundation-validation~="wcmio.email"]',
     validate: function(el) {
       var value = getValue(el);
       var valid = value.length === 0 || pattern.email.test(value);
@@ -57,7 +57,7 @@
 
   // predefined "url" pattern validator
   registry.register('foundation.validation.validator', {
-    selector: '[data-foundation-validation="wcmio.url"]',
+    selector: '[data-foundation-validation~="wcmio.url"]',
     validate: function(el) {
       var value = getValue(el);
       var valid = value.length === 0 || pattern.url.test(value);
@@ -69,7 +69,7 @@
 
   // predefined "path" pattern validator
   registry.register('foundation.validation.validator', {
-    selector: '[data-foundation-validation="wcmio.path"]',
+    selector: '[data-foundation-validation~="wcmio.path"]',
     validate: function(el) {
       var value = getValue(el);
       var valid = value.length === 0 || pattern.path.test(value);
@@ -81,7 +81,7 @@
 
   // "pattern" validator with custom regex pattern and message
   registry.register('foundation.validation.validator', {
-    selector: '[data-foundation-validation="wcmio.pattern"]',
+    selector: '[data-foundation-validation~="wcmio.pattern"]',
     validate: function(el) {
       el = $(el);
       var regex = el.attr("data-wcmio-pattern");

--- a/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
@@ -46,9 +46,11 @@ var assertInvalid = function(validate, value) {
   });
 }
 
+
+
 // assert validator implementation
 describe('wcmio.email', function() {
-  var validate = validators['[data-foundation-validation="wcmio.email"]'];
+  var validate = validators['[data-foundation-validation~="wcmio.email"]'];
   assertValid(validate, "firstname.lastname@mycompany.com");
   assertInvalid(validate, "http://myhost");
   assertInvalid(validate, "http://www.domain.com/path1");
@@ -65,7 +67,7 @@ describe('wcmio.email', function() {
 });
 
 describe('wcmio.url', function() {
-  var validate = validators['[data-foundation-validation="wcmio.url"]'];
+  var validate = validators['[data-foundation-validation~="wcmio.url"]'];
   assertInvalid(validate, "firstname.lastname@mycompany.com");
   assertValid(validate, "http://myhost");
   assertValid(validate, "http://www.domain.com/path1");
@@ -82,7 +84,7 @@ describe('wcmio.url', function() {
 });
 
 describe('wcmio.path', function() {
-  var validate = validators['[data-foundation-validation="wcmio.path"]'];
+  var validate = validators['[data-foundation-validation~="wcmio.path"]'];
   assertInvalid(validate, "firstname.lastname@mycompany.com");
   assertInvalid(validate, "http://myhost");
   assertInvalid(validate, "http://www.domain.com/path1");
@@ -99,7 +101,7 @@ describe('wcmio.path', function() {
 });
 
 describe('wcmio.pattern', function() {
-  var validate = validators['[data-foundation-validation="wcmio.pattern"]'];
+  var validate = validators['[data-foundation-validation~="wcmio.pattern"]'];
 
   it('matches pattern', function() {
     assert.equal(validate({


### PR DESCRIPTION
…foundation-)validation attribute, so that multiple validators can be used on a single field (in co-op with @rubnig)