### PR TITLE
Granite UI Show/Hide: Add category 'cq.sites.validations' to make the it available in create page wizard

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="1.10.6" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="15">
         Granite UI Show/Hide: Add category 'cq.sites.validations' to make the it available in create page wizard.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="1.10.6" date="not released">
+      <action type="update" dev="sseifert">
+        Granite UI Show/Hide: Add category 'cq.sites.validations' to make the it available in create page wizard.
+      </action>
+    </release>
+
     <release version="1.10.4" date="2024-03-21">
       <action type="update" dev="rubnig" issue="13">
         Granite UI Show/Hide: Support multiple options for Coral select component.

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields.json
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields.json
@@ -2,6 +2,7 @@
   "jcr:primaryType": "cq:ClientLibraryFolder",
   "categories": [
     "cq.authoring.dialog",
-    "cq.siteadmin.admin.properties"
+    "cq.siteadmin.admin.properties",
+    "cq.sites.validations"
   ]
 }


### PR DESCRIPTION
Although it's technically not fully correct to add the clientlib category `q.sites.validations`, but it's still close enough.

Unfortunately, the create page wizard dialog does not by default include the clientlib categories `cq.authoring.dialog` or `cq.siteadmin.admin.properties`, see `/libs/wcm/core/content/sites/createpagewizard/jcr:content/head/clientlibs`.

Fixes https://github.com/wcm-io/io.wcm.handler.link/issues/19