### PR TITLE
global.jsp: Get rid of deprecated Granite XSS API

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
       <action type="update" dev="rubnig" issue="22">
         Granite UI Show/Hide: Showhide support for textarea fields.
       </action>
+      <action type="update" dev="sseifert">
+        global.jsp: Get rid of deprecated Granite XSS API.
+      </action>
     </release>
 
     <release version="1.10.6" date="2025-03-04">

--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,7 @@
       <action type="update" dev="rubnig" issue="22">
         Granite UI Show/Hide: Showhide support for textarea fields.
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="43">
         global.jsp: Get rid of deprecated Granite XSS API.
       </action>
     </release>

--- a/src/main/webapp/app-root/components/global/global.jsp
+++ b/src/main/webapp/app-root/components/global/global.jsp
@@ -17,8 +17,7 @@
   limitations under the License.
   #L%
   --%>
-<%@page import="com.adobe.granite.xss.XSSAPI"%><%
-%><%@page import="com.day.cq.i18n.I18n"%><%
+<%@page import="com.day.cq.i18n.I18n"%><%
 %><%@page import="com.adobe.granite.ui.components.ComponentHelper"%><%
 %><%@page session="false" pageEncoding="UTF-8" contentType="text/html" %><%
 %><%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2" %><%
@@ -27,15 +26,5 @@
 
 final ComponentHelper cmp = new ComponentHelper(pageContext);
 final I18n i18n = cmp.getI18n();
-final XSSAPI xssAPI = cmp.getXss();
-
-%><%!
-String outVar(XSSAPI xssAPI, I18n i18n, String text) {
-  return xssAPI.encodeForHTML(i18n.getVar(text));
-}
-
-String outAttrVar(XSSAPI xssAPI, I18n i18n, String text) {
-  return xssAPI.encodeForHTMLAttr(i18n.getVar(text));
-}
 
 %>


### PR DESCRIPTION
it was never used in the actual Granite UI components