### PR TITLE
#48 fix required for foundation autocomplete

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
+    <release version="1.11.2" data="not released">
+      <action type="fix" dev="henrykuijpers" issue="48">
+        Granite UI Show/Hide: Fix bug with foundation-autocomplete becoming required while it should not be.
+      </action>
+    </release>
 
     <release version="1.11.0" date="not released">
       <action type="update" dev="henrykuijpers" issue="21"><![CDATA[

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "reporters": [
       "jest-standard-reporter"
     ],
-    "coverageDirectory": "target/jest-coverage"
+    "coverageDirectory": "target/jest-coverage",
+    "collectCoverageFrom": [
+      "**/src/**/*.js",
+      "!**/src/test/**/*.js"
+    ]
   }
 }

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -92,8 +92,6 @@
       });
     } else if (typeof component.value !== "undefined") {
       values.push(component.value);
-    } else if (typeof component.getValue === "function") {
-      values.push(component.getValue());
     } else {
       console.error('Unsupported component', component, 'and element', element);
     }
@@ -134,23 +132,21 @@
     if (show) {
       $element.removeClass("hide");
       $element.removeClass("wcmio-dialog-showhide-status-hide");
-      $element.find("[data-validation], [data-foundation-validation], input[aria-required=false], textarea[aria-required=false], coral-multifield[aria-required=false], foundation-autocomplete[aria-required=false]")
+      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=false]")
           .filter(":not(.hide>input)")
           .filter(":not(input.hide)")
           .filter(":not(.hide>textarea)")
           .filter(":not(textarea.hide)")
-
           .filter(":not(.hide>coral-multifield)")
           .filter(":not(input.coral-multifield)")
           .each(function (index, field) {
-            toggleValidation($(field));
+            toggleValidation($(field), true);
           });
     } else {
       $element.addClass("hide");
-      $element.find("[data-validation], [data-foundation-validation],input[aria-required=true], textarea[aria-required=true], coral-multifield[aria-required=true], foundation-autocomplete[required]")
-
+      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=true]")
           .each(function (index, field) {
-            toggleValidation($(field));
+            toggleValidation($(field), false);
           });
       $element.addClass("wcmio-dialog-showhide-status-hide");
     }
@@ -160,41 +156,34 @@
    * If the form element is not shown we have to disable the required validation for that field.
    *
    * @param {jQuery} $field To disable / enable required validation.
+   * @param {boolean} show Should the field be shown or hidden?
    */
-  function toggleValidation($field) {
-    var propRequired = $field.prop("required");
-    var ariaRequired = $field.attr("aria-required");
-    var isRequired = (ariaRequired === "true");
-
-    // skip toggle if the field is already hidden and validation was already toggled (in case of nested show/hide structures)
-    if ($field.parents(".wcmio-dialog-showhide-status-hide").length > 0) {
-      return;
-    }
-
-    ['validation', 'foundation-validation'].forEach(function(key) {
-      const attr = 'data-' + key;
-      const backup = 'data-was-' + key;
-      const value = $field.attr(attr);
-      const backupValue = $field.attr(backup);
-
-      if (backupValue !== undefined) {
-        $field.attr(attr, backupValue).removeAttr(backup);
-      } else if (value !== undefined) {
-        $field.attr(backup, value).removeAttr(attr);
+  function toggleValidation($field, show) {
+    [
+      {
+        name: 'data-validation',
+        tempName: 'data-was-validation'
+      },
+      {
+        name: 'data-foundation-validation',
+        tempName: 'data-was-foundation-validation'
+      },
+      {
+        name: 'aria-required',
+        tempName: 'data-was-aria-required'
+      },
+      {
+        name: 'required',
+        tempName: 'data-was-required'
+      }
+    ].forEach(function(obj) {
+      const attributeName = show ? obj.tempName : obj.name;
+      const value = $field.attr(attributeName);
+      $field.removeAttr(attributeName);
+      if (value) {
+        $field.attr(show ? obj.name : obj.tempName, value);
       }
     });
-
-    if ($field.is("foundation-autocomplete") && propRequired !== "undefined") {
-      if (propRequired === true) {
-        $field[0].required = false;
-        $field.attr("aria-required", false);
-      } else if (propRequired === false) {
-        $field[0].required = true;
-        $field.removeAttr("aria-required");
-      }
-    } else if (typeof ariaRequired !== "undefined") {
-      $field.attr("aria-required", String(!isRequired));
-    }
 
     var api = $field.adaptTo("foundation-validation");
     if (api) {

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -177,8 +177,8 @@
         tempName: 'data-was-required'
       }
     ].forEach(function(obj) {
-      const attributeName = show ? obj.tempName : obj.name;
-      const value = $field.attr(attributeName);
+      var attributeName = show ? obj.tempName : obj.name;
+      var value = $field.attr(attributeName);
       $field.removeAttr(attributeName);
       if (value) {
         $field.attr(show ? obj.name : obj.tempName, value);

--- a/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
@@ -25,8 +25,8 @@ expect.extend({
 window.$ = require('jquery');
 
 require('../mocks/coral/commons')(window);
-require('../mocks/granite/ui')(window, $);
-require('../mocks/foundation/validation')(window, $);
+require('../mocks/granite/ui')(window);
+require('../mocks/foundation/validation')(window);
 require('../../../main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js');
 
 $(window).adaptTo('foundation-registry').register('foundation.validation.validator', {
@@ -148,16 +148,27 @@ describe('dialog-showhide', () => {
                 <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".target" data-wcmio-dialog-showhide-parent=".content">
                     <input/>
                 </coral-checkbox>
-                <div class="coral-Form-fieldwrapper wcmio-dialog-showhide-status-hide target">
-                    <div id="test" data-showhidetargetvalue="false" data-foundation-validation="simple-attribute"></div>
+                <div class="coral-Form-fieldwrapper wcmio-dialog-showhide-status-hide target" data-showhidetargetvalue="true">
+                    <div id="test" data-foundation-validation="simple-attribute"></div>
                 </div>
             </div>
             `;
+            const checkbox = document.querySelector('coral-checkbox');
+            checkbox.checked = false;
+            checkbox.value = 'true';
+            const fieldWrapper = document.querySelector('.target');
+            const element = document.querySelector('#test');
             triggerContentLoaded();
-            // Should not be hidden by wcmio-dialog-showhide
-            expect(document.querySelector('#test')).not.toBeHidden();
+            // Should be hidden by wcmio-dialog-showhide
+            expect(fieldWrapper).toBeHidden();
             // Should not have validation triggered
-            expect(document.querySelector('#test')).not.toHaveAttribute('data-valid');
+            expect(element).toHaveAttribute('data-valid', 'true');
+            checkbox.checked = true;
+            $(checkbox).trigger('change');
+            // Should not be hidden by wcmio-dialog-showhide
+            expect(fieldWrapper).not.toBeHidden();
+            // Should have validation triggered
+            expect(element).toHaveAttribute('data-valid', 'false');
         });
 
         it('Supports "not" to invert the decision to show/hide the field', () => {
@@ -186,6 +197,25 @@ describe('dialog-showhide', () => {
             expect(trueItem).toBeHidden();
             expect(falseItem).not.toBeHidden();
             expect(emptyItem).not.toBeHidden();
+        });
+
+        it('Supports foundation-autocomplete', () => {
+            document.body.innerHTML = `
+            <div id="dialog">
+                <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".my-target"></coral-checkbox>
+                <foundation-autocomplete class="my-target" data-foundation-validation data-showhidetargetvalue="test">
+                </foundation-autocomplete>
+            </div>`;
+            const checkbox = document.querySelector('coral-checkbox');
+            const foundationAutocomplete = document.querySelector('foundation-autocomplete');
+
+            checkbox.value = 'test';
+            checkbox.checked = false;
+            triggerContentLoaded();
+            expect(foundationAutocomplete).toBeHidden();
+            checkbox.checked = true;
+            $(checkbox).trigger('change');
+            expect(foundationAutocomplete).not.toBeHidden();
         });
     });
 

--- a/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
@@ -1,39 +1,29 @@
 /**
  * @jest-environment jsdom
  */
+window.$ = require('jquery');
+require('../mocks/granite/ui')(window);
+require('../mocks/granite/i18n')(window);
+require('../mocks/foundation/validation')(window);
+
 describe('io.wcm.ui.granite.validation', () => {
-  let validators;
+  function validate(type, value, isValid, validationMessage, additionalProperties = {}) {
+    const el = document.createElement('input');
+    Object.entries({
+      'data-foundation-validation': type,
+      ...additionalProperties
+    }).forEach(([attributeName, attributeValue]) => el.setAttribute(attributeName, String(attributeValue)));
+    el.setAttribute('data-foundation-validation', type);
+    el.value = value;
+    const validator = $(el).adaptTo("foundation-validation");
+    expectValidationResult(validator, isValid, validationMessage);
+  }
 
   beforeAll(() => {
-    // Mock Granite and capture registered validators
-    validators = {};
-    window.Granite = {
-      $: (obj) => ({
-        adaptTo: (to) => {
-          if (to === 'foundation-registry') {
-            return {
-              register: (name, validator) => {
-                validators[validator.selector] = validator.validate;
-              }
-            };
-          }
-        },
-        val: () => obj.value,
-        attr: (param) => obj[param]
-      }),
-      I18n: {
-        get: (arg) => arg
-      }
-    };
     require('../../../main/webapp/app-root/clientlibs/io.wcm.ui.granite.validation/js/validation.js');
   });
 
   describe('wcmio.email', () => {
-    let validate;
-    beforeAll(() => {
-      validate = validators['[data-foundation-validation~="wcmio.email"]'];
-    });
-
     test.each([
       ["firstname.lastname@mycompany.com", true],
       ["http://myhost", false],
@@ -49,17 +39,11 @@ describe('io.wcm.ui.granite.validation', () => {
       ["/content/dam/sample.jpg", false],
       ["/ns1:this/is/ns2:a/path", false]
     ])('should validate "%s" as %s', (value, isValid) => {
-      const result = validate({ value });
-      expectValidationResult(result, isValid, "Please enter a valid email address.");
+      validate('wcmio.email', value, isValid, "Please enter a valid email address.");
     });
   });
 
   describe('wcmio.url', () => {
-    let validate;
-    beforeAll(() => {
-      validate = validators['[data-foundation-validation~="wcmio.url"]'];
-    });
-
     test.each([
       ["firstname.lastname@mycompany.com", false],
       ["http://myhost", true],
@@ -75,17 +59,11 @@ describe('io.wcm.ui.granite.validation', () => {
       ["/content/dam/sample.jpg", false],
       ["/ns1:this/is/ns2:a/path", false]
     ])('should validate "%s" as %s', (value, isValid) => {
-      const result = validate({ value });
-      expectValidationResult(result, isValid, "Please enter a valid URL.");
+      validate('wcmio.url', value, isValid, "Please enter a valid URL.");
     });
   });
 
   describe('wcmio.path', () => {
-    let validate;
-    beforeAll(() => {
-      validate = validators['[data-foundation-validation~="wcmio.path"]'];
-    });
-
     test.each([
       ["firstname.lastname@mycompany.com", false],
       ["http://myhost", false],
@@ -101,33 +79,19 @@ describe('io.wcm.ui.granite.validation', () => {
       ["/content/dam/sample.jpg", true],
       ["/ns1:this/is/ns2:a/path", true]
     ])('should validate "%s" as %s', (value, isValid) => {
-      const result = validate({ value });
-      expectValidationResult(result, isValid, "Please enter a valid content path.");
+      validate('wcmio.path', value, isValid, "Please enter a valid content path.");
     });
   });
 
   describe('wcmio.pattern', () => {
-    let validate;
-    beforeAll(() => {
-      validate = validators['[data-foundation-validation~="wcmio.pattern"]'];
-    });
-
-    test('matches pattern', () => {
-      const result = validate({
-        value: "abc",
-        "data-wcmio-pattern": "^ab.*$",
-        "data-wcmio-patternmessage": "Invalid."
+    test.each([
+        ["abc", "^ab.*$", true],
+        ["def", "^ab.*$", false]
+    ])('should validate "%s" as %s', (value, pattern, isValid) => {
+      validate('wcmio.pattern', value, isValid, "Invalid.", {
+        'data-wcmio-pattern': pattern,
+        'data-wcmio-patternmessage': "Invalid."
       });
-      expectValidationResult(result, true);
-    });
-
-    test('does not match pattern', () => {
-      const result = validate({
-        value: "def",
-        "data-wcmio-pattern": "^ab.*$",
-        "data-wcmio-patternmessage": "Invalid."
-      });
-      expectValidationResult(result, false, "Invalid.");
     });
   });
 });
@@ -137,11 +101,10 @@ describe('io.wcm.ui.granite.validation', () => {
  * If isValid is true, expects result to be null or undefined.
  * If isValid is false, expects result to be a string and matches expectedMessage.
  */
-function expectValidationResult(result, isValid, expectedMessage) {
-  if (isValid) {
-    expect(result === null || result === undefined).toBe(true);
-  }
-  else {
-    expect(result).toBe(expectedMessage);
+function expectValidationResult(validator, isValid, expectedMessage) {
+  const result = validator.checkValidity();
+  expect(result).toBe(isValid);
+  if (!isValid) {
+    expect(validator.message).toBe(expectedMessage);
   }
 }

--- a/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.validation/validation.test.js
@@ -16,7 +16,11 @@ describe('io.wcm.ui.granite.validation', () => {
     el.setAttribute('data-foundation-validation', type);
     el.value = value;
     const validator = $(el).adaptTo("foundation-validation");
-    expectValidationResult(validator, isValid, validationMessage);
+    const result = validator.checkValidity();
+    expect(result).toBe(isValid);
+    if (!isValid) {
+      expect(validator.message).toBe(validationMessage);
+    }
   }
 
   beforeAll(() => {
@@ -96,15 +100,3 @@ describe('io.wcm.ui.granite.validation', () => {
   });
 });
 
-/**
- * Helper to check validation result.
- * If isValid is true, expects result to be null or undefined.
- * If isValid is false, expects result to be a string and matches expectedMessage.
- */
-function expectValidationResult(validator, isValid, expectedMessage) {
-  const result = validator.checkValidity();
-  expect(result).toBe(isValid);
-  if (!isValid) {
-    expect(validator.message).toBe(expectedMessage);
-  }
-}

--- a/src/test/javascript/mocks/granite/i18n.js
+++ b/src/test/javascript/mocks/granite/i18n.js
@@ -1,0 +1,8 @@
+module.exports = function(window) {
+    window.Granite = window.Granite || {};
+    window.Granite.I18n = {
+        get: function (key) {
+            return key;
+        }
+    };
+};

--- a/src/test/javascript/mocks/granite/ui.js
+++ b/src/test/javascript/mocks/granite/ui.js
@@ -1,4 +1,4 @@
-module.exports = function(window, $) {
+module.exports = function(window) {
     window.Granite = window.Granite || {};
     window.Granite.$ = $;
     window.Granite.UI = {


### PR DESCRIPTION
* Correctly switch on/off required & validation, based on show/hide instead of just toggling
* Fix the "required"-check for foundation-autocomplete
* Collect coverage only from production code, not from unit tests
* Remove "component.getValue"-case, as it could not be triggered

Fixes #48 