### PR TITLE
Auto-detect latest implementation of PredicateProvider

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
-    <release version="1.11.2" data="not released">
+    <release version="1.11.2" date="not released">
+      <action type="update" dev="sseifert"><![CDATA[
+        Auto-detect latest implementation of PredicateProvider in package <code>com.day.cq.commons.predicates.PredicateProvider</code> or <code>com.day.cq.commons.predicate.PredicateProvider</code> to avoid warnings in AEMaaCS.
+        Get rid of dependency to Commons Collection 3 by using reflection for accessing the PredicateProvider.
+      ]]></action>
       <action type="fix" dev="henrykuijpers" issue="48">
         Granite UI Show/Hide: Fix bug with foundation-autocomplete becoming required while it should not be.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
     <release version="1.11.2" date="not released">
-      <action type="update" dev="sseifert"><![CDATA[
+      <action type="update" dev="sseifert" issue="50"><![CDATA[
         Auto-detect latest implementation of PredicateProvider in package <code>com.day.cq.commons.predicates.PredicateProvider</code> or <code>com.day.cq.commons.predicate.PredicateProvider</code> to avoid warnings in AEMaaCS.
         Get rid of dependency to Commons Collection 3 by using reflection for accessing the PredicateProvider.
       ]]></action>

--- a/changes.xml
+++ b/changes.xml
@@ -23,10 +23,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
+
     <release version="1.11.2" date="not released">
       <action type="update" dev="sseifert" issue="50"><![CDATA[
-        Auto-detect latest implementation of PredicateProvider in package <code>com.day.cq.commons.predicates.PredicateProvider</code> or <code>com.day.cq.commons.predicate.PredicateProvider</code> to avoid warnings in AEMaaCS.
-        Get rid of dependency to Commons Collection 3 by using reflection for accessing the PredicateProvider.
+        Auto-detect latest implementation of PredicateProvider in package <code>com.day.cq.commons.predicates.PredicateProvider</code> or <code>com.day.cq.commons.predicate.PredicateProvider</code> to avoid warnings in AEMaaCS.<br/>
+        Get rid of dependency to Commons Collection 3 by using reflection to access the legacy PredicateProvider.
       ]]></action>
       <action type="fix" dev="henrykuijpers" issue="48">
         Granite UI Show/Hide: Fix bug with foundation-autocomplete becoming required while it should not be.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
       <artifactId>commons-lang3</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
 <!-- (implicit reference in configScopePathBrowser JSP)
     <dependency>
@@ -85,8 +90,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
@@ -21,36 +21,33 @@ package io.wcm.wcm.ui.granite.pathfield.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
-import org.apache.commons.collections.IteratorUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.PredicateUtils;
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.iterators.FilterIterator;
-import org.apache.commons.collections.iterators.TransformIterator;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.PredicateUtils;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.iterators.FilterIterator;
+import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.adobe.granite.ui.components.Config;
 import com.adobe.granite.ui.components.ExpressionHelper;
@@ -59,10 +56,10 @@ import com.adobe.granite.ui.components.PagingIterator;
 import com.adobe.granite.ui.components.ds.AbstractDataSource;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.adobe.granite.ui.components.ds.EmptyDataSource;
-import com.day.cq.commons.predicate.PredicateProvider;
 
 import io.wcm.wcm.ui.granite.pathfield.impl.predicate.HideInternalContentPathsPredicate;
 import io.wcm.wcm.ui.granite.pathfield.impl.util.PredicatedResourceWrapper;
+import io.wcm.wcm.ui.granite.util.impl.PredicateProviderUtils;
 
 /**
  * Servlet implementing the data source for the path field widget.
@@ -75,12 +72,14 @@ public class PathFieldChildrenDatasourceServlet extends SlingSafeMethodsServlet 
 
   static final String RESOURCE_TYPE = "wcm-io/wcm/ui/granite/components/form/pathfield/datasources/children";
 
+  private BundleContext bundleContext;
   @Reference
   private ExpressionResolver expressionResolver;
-  @Reference
-  private PredicateProvider predicateProvider;
 
-  private static final Logger log = LoggerFactory.getLogger(PathFieldChildrenDatasourceServlet.class);
+  @Activate
+  private void activate(BundleContext bc) {
+    this.bundleContext = bc;
+  }
 
   @Override
   @SuppressWarnings("null")
@@ -133,33 +132,32 @@ public class PathFieldChildrenDatasourceServlet extends SlingSafeMethodsServlet 
       final String itemResourceType = cfg.get("itemResourceType", String.class);
       final String[] filter = new String[] { ex.get(cfg.get("filter", "hierarchyNotFile"), String.class) };
 
-      final Collection<Predicate> predicates = new ArrayList<>();
+      final Collection<Predicate<Resource>> predicates = new ArrayList<>();
       predicates.add(new HideInternalContentPathsPredicate());
-      predicates.addAll(toPredicates(filter));
+      predicates.addAll(PredicateProviderUtils.toPredicates(filter, bundleContext));
 
       if (searchName != null) {
         final Pattern searchNamePattern = Pattern.compile(Pattern.quote(searchName), Pattern.CASE_INSENSITIVE);
         predicates.add(obj -> {
-            Resource r = (Resource)obj;
+            Resource r = obj;
             return searchNamePattern.matcher(r.getName()).lookingAt();
         });
       }
 
-      final Predicate predicate = PredicateUtils.allPredicate(predicates);
-      final Transformer transformer = createTransformer(itemResourceType, predicate);
+      final Predicate<Resource> predicate = PredicateUtils.allPredicate(predicates);
+      final Transformer<Resource, Resource> transformer = createTransformer(itemResourceType, predicate);
 
       DataSource datasource = new AbstractDataSource() {
         @Override
-        @SuppressWarnings("unchecked")
         public Iterator<Resource> iterator() {
-          List<Resource> list = IteratorUtils.toList(new FilterIterator(parent.listChildren(), predicate));
+          List<Resource> list = IteratorUtils.toList(new FilterIterator<>(parent.listChildren(), predicate));
 
           // sort result set alphabetically - but only if parent node does not have orderable child nodes
           if (!isOrderableChildNodes(parent)) {
             Collections.sort(list, (Resource r1, Resource r2) -> r1.getName().compareTo(r2.getName()));
           }
 
-          return new TransformIterator(new PagingIterator<>(list.iterator(), offset, limit), transformer);
+          return new TransformIterator<>(new PagingIterator<>(list.iterator(), offset, limit), transformer);
         }
       };
 
@@ -169,29 +167,8 @@ public class PathFieldChildrenDatasourceServlet extends SlingSafeMethodsServlet 
     request.setAttribute(DataSource.class.getName(), ds);
   }
 
-  @SuppressWarnings("java:S2583") // filter may be null
-  private List<Predicate> toPredicates(@NotNull String[] filter) {
-    if (filter == null) {
-      return Collections.emptyList();
-    }
-    return Arrays.asList(filter).stream()
-        .filter(Objects::nonNull)
-        .map(item -> {
-          Predicate predicate = predicateProvider.getPredicate(item);
-          if (predicate != null) {
-            return predicate;
-          }
-          else {
-            log.warn("Unable to find predicate implementation for filter: {}", item);
-            return null;
-          }
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
-  }
-
-  private static Transformer createTransformer(final String itemResourceType, final Predicate predicate) {
-    return r -> new PredicatedResourceWrapper((Resource)r, predicate) {
+  private static Transformer<Resource, Resource> createTransformer(final String itemResourceType, final Predicate<Resource> predicate) {
+    return r -> new PredicatedResourceWrapper(r, predicate) {
       @Override
       public String getResourceType() {
         if (itemResourceType == null) {

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServlet.java
@@ -138,10 +138,7 @@ public class PathFieldChildrenDatasourceServlet extends SlingSafeMethodsServlet 
 
       if (searchName != null) {
         final Pattern searchNamePattern = Pattern.compile(Pattern.quote(searchName), Pattern.CASE_INSENSITIVE);
-        predicates.add(obj -> {
-            Resource r = obj;
-            return searchNamePattern.matcher(r.getName()).lookingAt();
-        });
+        predicates.add(resource -> searchNamePattern.matcher(resource.getName()).lookingAt());
       }
 
       final Predicate<Resource> predicate = PredicateUtils.allPredicate(predicates);

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/predicate/HideInternalContentPathsPredicate.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/predicate/HideInternalContentPathsPredicate.java
@@ -22,14 +22,14 @@ package io.wcm.wcm.ui.granite.pathfield.impl.predicate;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
 /**
  * Hide certain "AEM-internal" content paths when listing resource children.
  */
-public class HideInternalContentPathsPredicate implements Predicate {
+public class HideInternalContentPathsPredicate implements Predicate<Resource> {
 
   /**
    * List of paths that are hidden by default.
@@ -67,9 +67,9 @@ public class HideInternalContentPathsPredicate implements Predicate {
   private static final String CONTENT_ROOT_PATH = "/content";
 
   @Override
-  public boolean evaluate(Object object) {
+  public boolean evaluate(Resource resource) {
     // if resource is a resource on the first level (below root node), allow only /content
-    String path = ((Resource)object).getPath();
+    String path = resource.getPath();
     if (FIRST_LEVEL_PATH.matcher(path).matches()) {
       return StringUtils.equals(path, CONTENT_ROOT_PATH);
     }

--- a/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/util/PredicatedResourceWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/pathfield/impl/util/PredicatedResourceWrapper.java
@@ -21,9 +21,9 @@ package io.wcm.wcm.ui.granite.pathfield.impl.util;
 
 import java.util.Iterator;
 
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.iterators.FilterIterator;
-import org.apache.commons.collections.iterators.TransformIterator;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.iterators.FilterIterator;
+import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
 
@@ -32,13 +32,13 @@ import org.apache.sling.api.resource.ResourceWrapper;
  */
 public class PredicatedResourceWrapper extends ResourceWrapper {
 
-  private final Predicate predicate;
+  private final Predicate<Resource> predicate;
 
   /**
    * @param resource Resource
    * @param predicate Predicate
    */
-  public PredicatedResourceWrapper(Resource resource, Predicate predicate) {
+  public PredicatedResourceWrapper(Resource resource, Predicate<Resource> predicate) {
     super(resource);
     this.predicate = predicate;
   }
@@ -53,10 +53,10 @@ public class PredicatedResourceWrapper extends ResourceWrapper {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("null")
   public Iterator<Resource> listChildren() {
-    return new TransformIterator(new FilterIterator(super.listChildren(), predicate),
-        obj -> new PredicatedResourceWrapper((Resource)obj, predicate));
+    return new TransformIterator<>(new FilterIterator<>(super.listChildren(), predicate),
+        obj -> new PredicatedResourceWrapper(obj, predicate));
   }
 
   @Override

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/AbstractPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/AbstractPredicateProviderWrapper.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class AbstractPredicateProviderWrapper implements PredicateProviderWrapper {
+
+  private final ServiceReference<?> serviceReference;
+  private final BundleContext bundleContext;
+  private final Object service;
+  private Method getPredicateMethod;
+
+  protected final Logger log = LoggerFactory.getLogger(getClass());
+
+  AbstractPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
+    this.serviceReference = serviceReference;
+    this.bundleContext = bundleContext;
+    service = bundleContext.getService(serviceReference);
+    if (service != null) {
+      try {
+        getPredicateMethod = service.getClass().getMethod("getPredicate", String.class);
+      }
+      catch (NoSuchMethodException | SecurityException ex) {
+        log.warn("Legacy PredicateProvider service does not implement expected method 'getPredicate(String)'.", ex);
+      }
+    }
+  }
+
+  protected @Nullable Object getPredicateInternal(@NotNull String name) {
+    if (getPredicateMethod != null) {
+      try {
+        return getPredicateMethod.invoke(service, name);
+      }
+      catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+        log.warn("Error calling 'getPredicate(String)' method.", ex);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    bundleContext.ungetService(serviceReference);
+  }
+
+}

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/FallbackPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/FallbackPredicateProviderWrapper.java
@@ -35,7 +35,7 @@ class FallbackPredicateProviderWrapper implements PredicateProviderWrapper {
   }
 
   @Override
-  public void unget() {
+  public void close() throws Exception {
     // nothing to do
   }
 

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/FallbackPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/FallbackPredicateProviderWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Fallback implementation of PredicateProviderWrapper that does not provide any predicates.
+ */
+class FallbackPredicateProviderWrapper implements PredicateProviderWrapper {
+
+  @Override
+  public @Nullable Predicate<Resource> getPredicate(@NotNull String name) {
+    return null;
+  }
+
+  @Override
+  public void unget() {
+    // nothing to do
+  }
+
+}

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
@@ -26,6 +26,9 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+/**
+ * Wrapper for latest PredicateProvider implementation that returns java.util.function.Predicate.
+ */
 class LatestPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
 
   LatestPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
@@ -31,16 +31,16 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class LegacyPredicateProviderWrapper implements PredicateProviderWrapper {
+class LatestPredicateProviderWrapper implements PredicateProviderWrapper {
 
   private final ServiceReference<?> serviceReference;
   private final BundleContext bundleContext;
   private final Object service;
   private Method getPredicateMethod;
 
-  private static final Logger log = LoggerFactory.getLogger(LegacyPredicateProviderWrapper.class);
+  private static final Logger log = LoggerFactory.getLogger(LatestPredicateProviderWrapper.class);
 
-  LegacyPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
+  LatestPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
     this.serviceReference = serviceReference;
     this.bundleContext = bundleContext;
     service = bundleContext.getService(serviceReference);
@@ -58,19 +58,11 @@ class LegacyPredicateProviderWrapper implements PredicateProviderWrapper {
   public @Nullable Predicate<Resource> getPredicate(@NotNull String name) {
     if (getPredicateMethod != null) {
       try {
-        Object predicate = getPredicateMethod.invoke(service, name);
-        Method evaluateMethod = predicate.getClass().getMethod("evaluate", Object.class);
-        return resource -> {
-          try {
-            return Boolean.TRUE.equals(evaluateMethod.invoke(predicate, resource));
-          }
-          catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
-            return false;
-          }
-        };
+        @SuppressWarnings("unchecked")
+        java.util.function.Predicate<Resource> predicate = (java.util.function.Predicate)getPredicateMethod.invoke(service, name);
+        return predicate::test;
       }
-      catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException ex) {
+      catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
         log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
       }
 

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
@@ -19,60 +19,27 @@
  */
 package io.wcm.wcm.ui.granite.util.impl;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import org.apache.commons.collections4.Predicate;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class LatestPredicateProviderWrapper implements PredicateProviderWrapper {
-
-  private final ServiceReference<?> serviceReference;
-  private final BundleContext bundleContext;
-  private final Object service;
-  private Method getPredicateMethod;
-
-  private static final Logger log = LoggerFactory.getLogger(LatestPredicateProviderWrapper.class);
+class LatestPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
 
   LatestPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
-    this.serviceReference = serviceReference;
-    this.bundleContext = bundleContext;
-    service = bundleContext.getService(serviceReference);
-    if (service != null) {
-      try {
-        getPredicateMethod = service.getClass().getMethod("getPredicate", String.class);
-      }
-      catch (NoSuchMethodException | SecurityException ex) {
-        log.warn("Legacy PredicateProvider service does not implement expected method 'getPredicate(String)'.", ex);
-      }
-    }
+    super(serviceReference, bundleContext);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public @Nullable Predicate<Resource> getPredicate(@NotNull String name) {
-    if (getPredicateMethod != null) {
-      try {
-        @SuppressWarnings("unchecked")
-        java.util.function.Predicate<Resource> predicate = (java.util.function.Predicate)getPredicateMethod.invoke(service, name);
-        return predicate::test;
-      }
-      catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-        log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
-      }
-
+    java.util.function.Predicate<Resource> predicate = (java.util.function.Predicate)getPredicateInternal(name);
+    if (predicate == null) {
+      return null;
     }
-    return null;
-  }
-
-  @Override
-  public void close() {
-    bundleContext.ungetService(serviceReference);
+    return predicate::test;
   }
 
 }

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LatestPredicateProviderWrapper.java
@@ -31,6 +31,8 @@ import org.osgi.framework.ServiceReference;
  */
 class LatestPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
 
+  private static final String NODE_PREDICATE_INTERFACE = "com.day.cq.commons.predicates.NodePredicate";
+
   LatestPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
     super(serviceReference, bundleContext);
   }
@@ -42,7 +44,24 @@ class LatestPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
     if (predicate == null) {
       return null;
     }
+    if (isNodePredicate(predicate)) {
+      return new NodePredicateWrapper((java.util.function.Predicate)predicate)::test;
+    }
     return predicate::test;
+  }
+
+  /**
+   * Checks if the given predicate implementation implements the NodePredicate interface.
+   * @param obj Predicate implementation
+   * @return true if NodePredicate
+   */
+  private static boolean isNodePredicate(Object obj) {
+    for (Class<?> intf : obj.getClass().getInterfaces()) {
+      if (NODE_PREDICATE_INTERFACE.equals(intf.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
@@ -29,6 +29,9 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+/**
+ * Wrapper for legacy PredicateProvider implementation that returns Commons Collection 3 Predicate.
+ */
 class LegacyPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
 
   LegacyPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class LegacyPredicateProviderWrapper implements PredicateProviderWrapper {
+
+  private final ServiceReference<?> serviceReference;
+  private final BundleContext bundleContext;
+  private final Object service;
+  private Method getPredicateMethod;
+
+  private static final Logger log = LoggerFactory.getLogger(LegacyPredicateProviderWrapper.class);
+
+  LegacyPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
+    this.serviceReference = serviceReference;
+    this.bundleContext = bundleContext;
+    service = bundleContext.getService(serviceReference);
+    if (service != null) {
+      try {
+        getPredicateMethod = service.getClass().getMethod("getPredicate", String.class);
+      }
+      catch (NoSuchMethodException | SecurityException ex) {
+        log.warn("Legacy PredicateProvider service does not implement expected method 'getPredicate(String)'.", ex);
+      }
+    }
+  }
+
+  @Override
+  public @Nullable Predicate<Resource> getPredicate(@NotNull String name) {
+    if (getPredicateMethod != null) {
+      try {
+        Object predicate = getPredicateMethod.invoke(service, name);
+        Method evaluateMethod = predicate.getClass().getMethod("evaluate", Object.class);
+        return resource -> {
+          try {
+            return Boolean.TRUE.equals(evaluateMethod.invoke(predicate, resource));
+          }
+          catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
+            return false;
+          }
+        };
+      }
+      catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException ex) {
+        log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
+      }
+
+    }
+    return null;
+  }
+
+  @Override
+  public void unget() {
+    bundleContext.ungetService(serviceReference);
+  }
+
+}

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/LegacyPredicateProviderWrapper.java
@@ -28,38 +28,20 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class LegacyPredicateProviderWrapper implements PredicateProviderWrapper {
-
-  private final ServiceReference<?> serviceReference;
-  private final BundleContext bundleContext;
-  private final Object service;
-  private Method getPredicateMethod;
-
-  private static final Logger log = LoggerFactory.getLogger(LegacyPredicateProviderWrapper.class);
+class LegacyPredicateProviderWrapper extends AbstractPredicateProviderWrapper {
 
   LegacyPredicateProviderWrapper(ServiceReference<?> serviceReference, BundleContext bundleContext) {
-    this.serviceReference = serviceReference;
-    this.bundleContext = bundleContext;
-    service = bundleContext.getService(serviceReference);
-    if (service != null) {
-      try {
-        getPredicateMethod = service.getClass().getMethod("getPredicate", String.class);
-      }
-      catch (NoSuchMethodException | SecurityException ex) {
-        log.warn("Legacy PredicateProvider service does not implement expected method 'getPredicate(String)'.", ex);
-      }
-    }
+    super(serviceReference, bundleContext);
   }
 
   @Override
   public @Nullable Predicate<Resource> getPredicate(@NotNull String name) {
-    if (getPredicateMethod != null) {
+    Object predicate = getPredicateInternal(name);
+    if (predicate != null) {
+      Method evaluateMethod;
       try {
-        Object predicate = getPredicateMethod.invoke(service, name);
-        Method evaluateMethod = predicate.getClass().getMethod("evaluate", Object.class);
+        evaluateMethod = predicate.getClass().getMethod("evaluate", Object.class);
         return resource -> {
           try {
             return Boolean.TRUE.equals(evaluateMethod.invoke(predicate, resource));
@@ -70,17 +52,11 @@ class LegacyPredicateProviderWrapper implements PredicateProviderWrapper {
           }
         };
       }
-      catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException ex) {
-        log.warn("Error calling 'getPredicate(String)' on legacy PredicateProvider service.", ex);
+      catch (NoSuchMethodException | SecurityException ex) {
+        log.warn("Legacy Predicate does not implement expected method 'evaluate(Object)'.", ex);
       }
-
     }
     return null;
-  }
-
-  @Override
-  public void close() {
-    bundleContext.ungetService(serviceReference);
   }
 
 }

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/NodePredicateWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/NodePredicateWrapper.java
@@ -17,15 +17,29 @@
  * limitations under the License.
  * #L%
  */
-package com.day.cq.commons.predicates;
+package io.wcm.wcm.ui.granite.util.impl;
 
 import java.util.function.Predicate;
 
-/**
- * This new predicate provider interface is introduced in AEMaaCS API in 2024.
- */
-public interface PredicateProvider {
+import javax.jcr.Node;
 
-  Predicate getPredicate(String name);
+import org.apache.sling.api.resource.Resource;
+
+class NodePredicateWrapper implements Predicate<Resource> {
+
+  private final Predicate<Node> delegate;
+
+  NodePredicateWrapper(Predicate<Node> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean test(Resource resource) {
+    Node node = resource.adaptTo(Node.class);
+    if (node != null) {
+      return delegate.test(node);
+    }
+    return false;
+  }
 
 }

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets predicate instances from AEM PredicateProvider.
+ *
+ * <p>
+ * Tries to get them from latest implementation from <code>com.day.cq.commons.predicates.PredicateProvider</code>
+ * first (introduced in AEMaaCS API in 2025), and if that's not available, falls back to
+ * <code>com.day.cq.commons.predicate.PredicateProvider</code> (also available in AEM 6.x).
+ * </p>
+ */
+public final class PredicateProviderUtils {
+
+  private static final String PREDICATE_PROVIDER_CLASS_NAME_LATEST = "com.day.cq.commons.predicates.PredicateProvider";
+  private static final String PREDICATE_PROVIDER_CLASS_NAME_LEGACY = "com.day.cq.commons.predicate.PredicateProvider";
+
+  private static final Logger log = LoggerFactory.getLogger(PredicateProviderUtils.class);
+
+  private PredicateProviderUtils() {
+    // static methods only
+  }
+
+  /**
+   * Get list of predicates for given filter names.
+   * @param filter Array of filter names
+   * @param bundleContext OSGi bundle context
+   * @return List of predicates
+   */
+  @SuppressWarnings({ "java:S2583", "null" }) // filter may be null
+  public static @NotNull List<Predicate<Resource>> toPredicates(@NotNull String[] filter, @NotNull BundleContext bundleContext) {
+    if (filter == null) {
+      return Collections.emptyList();
+    }
+    PredicateProviderWrapper predicateProvider = getPredicateProvider(bundleContext);
+    return Arrays.asList(filter).stream()
+        .filter(Objects::nonNull)
+        .map(item -> {
+          Predicate<Resource> predicate = predicateProvider.getPredicate(item);
+          if (predicate != null) {
+            return predicate;
+          }
+          else {
+            log.warn("Unable to find predicate implementation for filter: {}", item);
+            return null;
+          }
+        })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  private static @NotNull PredicateProviderWrapper getPredicateProvider(@NotNull BundleContext bundleContext) {
+    ServiceReference<?> serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LEGACY);
+    if (serviceReference != null) {
+      log.debug("Using legacy PredicateProvider implementation: {}", PREDICATE_PROVIDER_CLASS_NAME_LEGACY);
+      return new LegacyPredicateProviderWrapper(serviceReference, bundleContext);
+    }
+    log.warn("No PredicateProvider implementation found.");
+    return new FallbackPredicateProviderWrapper();
+  }
+
+}

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>
  * Tries to get them from latest implementation from <code>com.day.cq.commons.predicates.PredicateProvider</code>
- * first (introduced in AEMaaCS API in 2025), and if that's not available, falls back to
+ * first (introduced in AEMaaCS API in 2024), and if that's not available, falls back to
  * <code>com.day.cq.commons.predicate.PredicateProvider</code> (also available in AEM 6.x).
  * </p>
  */

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
@@ -64,25 +64,35 @@ public final class PredicateProviderUtils {
     if (filter == null) {
       return Collections.emptyList();
     }
-    PredicateProviderWrapper predicateProvider = getPredicateProvider(bundleContext);
-    return Arrays.asList(filter).stream()
-        .filter(Objects::nonNull)
-        .map(item -> {
-          Predicate<Resource> predicate = predicateProvider.getPredicate(item);
-          if (predicate != null) {
-            return predicate;
-          }
-          else {
-            log.warn("Unable to find predicate implementation for filter: {}", item);
-            return null;
-          }
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+    try (PredicateProviderWrapper predicateProvider = getPredicateProvider(bundleContext)) {
+      return Arrays.asList(filter).stream()
+          .filter(Objects::nonNull)
+          .map(item -> {
+            Predicate<Resource> predicate = predicateProvider.getPredicate(item);
+            if (predicate != null) {
+              return predicate;
+            }
+            else {
+              log.warn("Unable to find predicate implementation for filter: {}", item);
+              return null;
+            }
+          })
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+    }
+    catch (Exception ex) {
+      log.warn("Unable to close predicate provider.", ex);
+      return Collections.emptyList();
+    }
   }
 
   private static @NotNull PredicateProviderWrapper getPredicateProvider(@NotNull BundleContext bundleContext) {
-    ServiceReference<?> serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LEGACY);
+    ServiceReference<?> serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LATEST);
+    if (serviceReference != null) {
+      log.debug("Using legacy PredicateProvider implementation: {}", PREDICATE_PROVIDER_CLASS_NAME_LATEST);
+      return new LatestPredicateProviderWrapper(serviceReference, bundleContext);
+    }
+    serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LEGACY);
     if (serviceReference != null) {
       log.debug("Using legacy PredicateProvider implementation: {}", PREDICATE_PROVIDER_CLASS_NAME_LEGACY);
       return new LegacyPredicateProviderWrapper(serviceReference, bundleContext);

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
@@ -90,7 +90,7 @@ public final class PredicateProviderUtils {
   private static @NotNull PredicateProviderWrapper getPredicateProvider(@NotNull BundleContext bundleContext) {
     ServiceReference<?> serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LATEST);
     if (serviceReference != null) {
-      log.debug("Using legacy PredicateProvider implementation: {}", PREDICATE_PROVIDER_CLASS_NAME_LATEST);
+      log.debug("Using latest PredicateProvider implementation: {}", PREDICATE_PROVIDER_CLASS_NAME_LATEST);
       return new LatestPredicateProviderWrapper(serviceReference, bundleContext);
     }
     serviceReference = bundleContext.getServiceReference(PREDICATE_PROVIDER_CLASS_NAME_LEGACY);

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtils.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.Predicate;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
@@ -60,8 +61,8 @@ public final class PredicateProviderUtils {
    * @return List of predicates
    */
   @SuppressWarnings({ "java:S2583", "null" }) // filter may be null
-  public static @NotNull List<Predicate<Resource>> toPredicates(@NotNull String[] filter, @NotNull BundleContext bundleContext) {
-    if (filter == null) {
+  public static @NotNull List<Predicate<Resource>> toPredicates(@NotNull String @Nullable [] filter, @NotNull BundleContext bundleContext) {
+    if (filter == null || filter.length == 0) {
       return Collections.emptyList();
     }
     try (PredicateProviderWrapper predicateProvider = getPredicateProvider(bundleContext)) {

--- a/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderWrapper.java
+++ b/src/main/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderWrapper.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+interface PredicateProviderWrapper {
+
+  @Nullable
+  Predicate<Resource> getPredicate(@NotNull String name);
+
+  void unget();
+
+}

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -35,11 +35,6 @@ Additionally a set of [Granite UI validators][validation] is provided which can 
 |0.x                               |AEM 6.0+
 
 
-### Usage of deprecated APIs
-
-This module uses the API `org.apache.commons.collections` (Commons Collections 3) which is marked as deprecated in AEM. However, it's also baked into the AEM product API itself ([PredicateProvider](https://developer.adobe.com/experience-manager/reference-materials/cloud-service/javadoc/com/day/cq/commons/predicate/PredicateProvider.html) directly references [Commons Collections 3 Predicate](https://developer.adobe.com/experience-manager/reference-materials/cloud-service/javadoc/org/apache/commons/collections/Predicate.html). So this is unavoidable, unless Adobe changes the AEM product API.
-
-
 ### GitHub Repository
 
 Sources: https://github.com/wcm-io/io.wcm.wcm.ui.granite

--- a/src/test/java/com/day/cq/commons/predicates/HierarchyNotFilePredicate.java
+++ b/src/test/java/com/day/cq/commons/predicates/HierarchyNotFilePredicate.java
@@ -19,13 +19,30 @@
  */
 package com.day.cq.commons.predicates;
 
-import java.util.function.Predicate;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.commons.jcr.JcrConstants;
 
 /**
- * This new predicate provider interface is introduced in AEMaaCS API in 2024.
+ * New predicate implementation that is introduced in AEMaaCS API in 2024.
  */
-public interface PredicateProvider {
+public class HierarchyNotFilePredicate implements NodePredicate {
 
-  Predicate getPredicate(String name);
+  private final Logger log = LoggerFactory.getLogger(HierarchyNotFilePredicate.class);
 
+  @Override
+  public boolean test(Node node) {
+    try {
+      return node.isNodeType(JcrConstants.NT_HIERARCHYNODE) && !node.isNodeType(JcrConstants.NT_FILE);
+    }
+    catch (RepositoryException ex) {
+      log.warn("Error evaluating predciate.", ex);
+    }
+    return false;
+  }
 }
+

--- a/src/test/java/com/day/cq/commons/predicates/NodePredicate.java
+++ b/src/test/java/com/day/cq/commons/predicates/NodePredicate.java
@@ -21,11 +21,13 @@ package com.day.cq.commons.predicates;
 
 import java.util.function.Predicate;
 
-/**
- * This new predicate provider interface is introduced in AEMaaCS API in 2024.
- */
-public interface PredicateProvider {
+import javax.jcr.Node;
 
-  Predicate getPredicate(String name);
+/**
+ * New NodePredicate interface is introduced in AEMaaCS API in 2024.
+ */
+public interface NodePredicate extends Predicate<Node> {
+
+  // no implementation
 
 }

--- a/src/test/java/com/day/cq/commons/predicates/PredicateProvider.java
+++ b/src/test/java/com/day/cq/commons/predicates/PredicateProvider.java
@@ -17,16 +17,15 @@
  * limitations under the License.
  * #L%
  */
-package io.wcm.wcm.ui.granite.util.impl;
+package com.day.cq.commons.predicates;
 
-import org.apache.commons.collections4.Predicate;
-import org.apache.sling.api.resource.Resource;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import java.util.function.Predicate;
 
-interface PredicateProviderWrapper extends AutoCloseable {
+/**
+ * This new predicate provider interface is introduced in AEMaaCS API in 2025.
+ */
+public interface PredicateProvider {
 
-  @Nullable
-  Predicate<Resource> getPredicate(@NotNull String name);
+  Predicate getPredicate(String name);
 
 }

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLatestPredicateProvider.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLatestPredicateProvider.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.pathfield.impl;
+
+import java.util.function.Predicate;
+
+import com.day.cq.commons.predicates.PredicateProvider;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+
+public class DummyLatestPredicateProvider implements PredicateProvider {
+
+  public static final String PREDICATE_NAME = "predicate.name";
+
+  private final AemContext context;
+
+  DummyLatestPredicateProvider(AemContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Predicate getPredicate(String name) {
+    org.apache.commons.collections.Predicate[] predicates = context.getServices(org.apache.commons.collections.Predicate.class,
+        "(" + PREDICATE_NAME + "=" + name + ")");
+    if (predicates.length > 0) {
+      return predicates[0]::evaluate;
+    }
+    else {
+      return null;
+    }
+  }
+
+}

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLatestPredicateProvider.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLatestPredicateProvider.java
@@ -37,14 +37,20 @@ public class DummyLatestPredicateProvider implements PredicateProvider {
 
   @Override
   public Predicate getPredicate(String name) {
-    org.apache.commons.collections.Predicate[] predicates = context.getServices(org.apache.commons.collections.Predicate.class,
+    Predicate[] predicates = context.getServices(Predicate.class,
         "(" + PREDICATE_NAME + "=" + name + ")");
     if (predicates.length > 0) {
-      return predicates[0]::evaluate;
+      return predicates[0];
     }
     else {
-      return null;
+      // fallback to old predicate implementations
+      org.apache.commons.collections.Predicate[] commonsPredicates = context.getServices(org.apache.commons.collections.Predicate.class,
+          "(" + PREDICATE_NAME + "=" + name + ")");
+      if (commonsPredicates.length > 0) {
+        return commonsPredicates[0]::evaluate;
+      }
     }
+    return null;
   }
 
 }

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLegacyPredicateProvider.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyLegacyPredicateProvider.java
@@ -25,13 +25,13 @@ import com.day.cq.commons.predicate.PredicateProvider;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 
-public class DummyPredicateProvider implements PredicateProvider {
+public class DummyLegacyPredicateProvider implements PredicateProvider {
 
   public static final String PREDICATE_NAME = "predicate.name";
 
   private final AemContext context;
 
-  DummyPredicateProvider(AemContext context) {
+  DummyLegacyPredicateProvider(AemContext context) {
     this.context = context;
   }
 

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyPredicateProvider.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/DummyPredicateProvider.java
@@ -25,7 +25,7 @@ import com.day.cq.commons.predicate.PredicateProvider;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 
-class DummyPredicateProvider implements PredicateProvider {
+public class DummyPredicateProvider implements PredicateProvider {
 
   public static final String PREDICATE_NAME = "predicate.name";
 

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLatestPredicateProviderTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLatestPredicateProviderTest.java
@@ -62,7 +62,7 @@ class PathFieldChildrenDatasourceServletLatestPredicateProviderTest {
         PREDICATE_NAME, "folder");
     context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsHierarchyNodePredicate(),
         PREDICATE_NAME, "hierarchy");
-    context.registerService(Predicate.class, new com.day.cq.commons.predicate.HierarchyNotFilePredicate(),
+    context.registerService(java.util.function.Predicate.class, new com.day.cq.commons.predicates.HierarchyNotFilePredicate(),
         PREDICATE_NAME, "hierarchyNotFile");
     context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsNoSystemNodePredicate(),
         PREDICATE_NAME, "nosystem");

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLatestPredicateProviderTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLatestPredicateProviderTest.java
@@ -23,7 +23,7 @@ import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
 import static com.day.cq.commons.jcr.JcrConstants.NT_FILE;
 import static com.day.cq.commons.jcr.JcrConstants.NT_HIERARCHYNODE;
 import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
-import static io.wcm.wcm.ui.granite.pathfield.impl.DummyPredicateProvider.PREDICATE_NAME;
+import static io.wcm.wcm.ui.granite.pathfield.impl.DummyLegacyPredicateProvider.PREDICATE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -40,14 +40,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.adobe.granite.ui.components.ExpressionResolver;
 import com.adobe.granite.ui.components.ds.DataSource;
-import com.day.cq.commons.predicate.PredicateProvider;
+import com.day.cq.commons.predicates.PredicateProvider;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import io.wcm.wcm.ui.granite.testcontext.MockExpressionResolver;
 
 @ExtendWith(AemContextExtension.class)
-class PathFieldChildrenDatasourceServletTest {
+class PathFieldChildrenDatasourceServletLatestPredicateProviderTest {
 
   private final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
 
@@ -56,7 +56,7 @@ class PathFieldChildrenDatasourceServletTest {
   @BeforeEach
   void setUp() {
     context.registerService(ExpressionResolver.class, new MockExpressionResolver());
-    context.registerService(PredicateProvider.class, new DummyPredicateProvider(context));
+    context.registerService(PredicateProvider.class, new DummyLatestPredicateProvider(context));
 
     context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsFolderPredicate(),
         PREDICATE_NAME, "folder");

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLegacyPredicateProviderTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletLegacyPredicateProviderTest.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.pathfield.impl;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_FILE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_HIERARCHYNODE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
+import static io.wcm.wcm.ui.granite.pathfield.impl.DummyLegacyPredicateProvider.PREDICATE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.adobe.granite.ui.components.ExpressionResolver;
+import com.adobe.granite.ui.components.ds.DataSource;
+import com.day.cq.commons.predicate.PredicateProvider;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.ui.granite.testcontext.MockExpressionResolver;
+
+@ExtendWith(AemContextExtension.class)
+class PathFieldChildrenDatasourceServletLegacyPredicateProviderTest {
+
+  private final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+
+  private PathFieldChildrenDatasourceServlet underTest;
+
+  @BeforeEach
+  void setUp() {
+    context.registerService(ExpressionResolver.class, new MockExpressionResolver());
+    context.registerService(PredicateProvider.class, new DummyLegacyPredicateProvider(context));
+
+    context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsFolderPredicate(),
+        PREDICATE_NAME, "folder");
+    context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsHierarchyNodePredicate(),
+        PREDICATE_NAME, "hierarchy");
+    context.registerService(Predicate.class, new com.day.cq.commons.predicate.HierarchyNotFilePredicate(),
+        PREDICATE_NAME, "hierarchyNotFile");
+    context.registerService(Predicate.class, new com.day.cq.commons.predicate.IsNoSystemNodePredicate(),
+        PREDICATE_NAME, "nosystem");
+
+    underTest = context.registerInjectActivateService(new PathFieldChildrenDatasourceServlet());
+
+    context.currentResource(context.create().resource("/apps/picker",
+        "sling:resourceType", PathFieldChildrenDatasourceServlet.RESOURCE_TYPE));
+
+    context.build().resource("/content/l1", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .siblingsMode()
+        .resource("l1b", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("l1a", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("file", JCR_PRIMARYTYPE, NT_FILE);
+
+  }
+
+  @Test
+  void testHierarchyNotFilePredicate() {
+    Map<String, Object> props = Map.of(
+        "path", "/content/l1",
+        "filter", "hierarchyNotFile");
+    assertResultPaths(props,
+        "/content/l1/l1a",
+        "/content/l1/l1b");
+  }
+
+  @Test
+  void testNoSystemPredicate() {
+    Map<String, Object> props = Map.of(
+        "path", "/content/l1",
+        "filter", "nosystem");
+    assertResultPaths(props,
+        "/content/l1/file",
+        "/content/l1/l1a",
+        "/content/l1/l1b");
+  }
+
+  @Test
+  void testQuery() {
+    Map<String, Object> props = Map.of(
+        "query", "fi",
+        "rootPath", "/content/l1",
+        "filter", "nosystem");
+    assertResultPaths(props,
+        "/content/l1/file");
+  }
+
+  @Test
+  void testHierarchyNotFilePredicate_OrderedChildNodes() {
+    context.build().resource("/content/l2", JCR_PRIMARYTYPE, NT_UNSTRUCTURED)
+        .siblingsMode()
+        .resource("l2b", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("l2a", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("file", JCR_PRIMARYTYPE, NT_FILE);
+
+    Map<String, Object> props = Map.of(
+        "path", "/content/l2",
+        "filter", "hierarchyNotFile");
+    assertResultPaths(props,
+        "/content/l2/l2b",
+        "/content/l2/l2a");
+  }
+
+  private void assertResultPaths(Map<String, Object> props, String... paths) {
+    context.create().resource("/apps/picker/datasource", props);
+    try {
+      underTest.doGet(context.request(), context.response());
+    }
+    catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+    DataSource ds = (DataSource)context.request().getAttribute(DataSource.class.getName());
+    List<String> actualPaths = IteratorUtils.toList(ds.iterator()).stream().map(Resource::getPath).collect(Collectors.toList());
+    List<String> expectedPaths = List.of(paths);
+    assertEquals(expectedPaths, actualPaths);
+  }
+
+}

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletNoPredicateProviderTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/PathFieldChildrenDatasourceServletNoPredicateProviderTest.java
@@ -1,0 +1,133 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2019 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.pathfield.impl;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_FILE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_HIERARCHYNODE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.adobe.granite.ui.components.ExpressionResolver;
+import com.adobe.granite.ui.components.ds.DataSource;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.ui.granite.testcontext.MockExpressionResolver;
+
+@ExtendWith(AemContextExtension.class)
+class PathFieldChildrenDatasourceServletNoPredicateProviderTest {
+
+  private final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+
+  private PathFieldChildrenDatasourceServlet underTest;
+
+  @BeforeEach
+  void setUp() {
+    context.registerService(ExpressionResolver.class, new MockExpressionResolver());
+
+    underTest = context.registerInjectActivateService(new PathFieldChildrenDatasourceServlet());
+
+    context.currentResource(context.create().resource("/apps/picker",
+        "sling:resourceType", PathFieldChildrenDatasourceServlet.RESOURCE_TYPE));
+
+    context.build().resource("/content/l1", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .siblingsMode()
+        .resource("l1b", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("l1a", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("file", JCR_PRIMARYTYPE, NT_FILE);
+
+  }
+
+  @Test
+  void testHierarchyNotFilePredicate() {
+    Map<String, Object> props = Map.of(
+        "path", "/content/l1",
+        "filter", "hierarchyNotFile");
+    assertResultPaths(props,
+        "/content/l1/file",
+        "/content/l1/l1a",
+        "/content/l1/l1b");
+  }
+
+  @Test
+  void testNoSystemPredicate() {
+    Map<String, Object> props = Map.of(
+        "path", "/content/l1",
+        "filter", "nosystem");
+    assertResultPaths(props,
+        "/content/l1/file",
+        "/content/l1/l1a",
+        "/content/l1/l1b");
+  }
+
+  @Test
+  void testQuery() {
+    Map<String, Object> props = Map.of(
+        "query", "fi",
+        "rootPath", "/content/l1",
+        "filter", "nosystem");
+    assertResultPaths(props,
+        "/content/l1/file");
+  }
+
+  @Test
+  void testHierarchyNotFilePredicate_OrderedChildNodes() {
+    context.build().resource("/content/l2", JCR_PRIMARYTYPE, NT_UNSTRUCTURED)
+        .siblingsMode()
+        .resource("l2b", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("l2a", JCR_PRIMARYTYPE, NT_HIERARCHYNODE)
+        .resource("file", JCR_PRIMARYTYPE, NT_FILE);
+
+    Map<String, Object> props = Map.of(
+        "path", "/content/l2",
+        "filter", "hierarchyNotFile");
+    assertResultPaths(props,
+        "/content/l2/l2b",
+        "/content/l2/l2a",
+        "/content/l2/file");
+  }
+
+  private void assertResultPaths(Map<String, Object> props, String... paths) {
+    context.create().resource("/apps/picker/datasource", props);
+    try {
+      underTest.doGet(context.request(), context.response());
+    }
+    catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+    DataSource ds = (DataSource)context.request().getAttribute(DataSource.class.getName());
+    List<String> actualPaths = IteratorUtils.toList(ds.iterator()).stream().map(Resource::getPath).collect(Collectors.toList());
+    List<String> expectedPaths = List.of(paths);
+    assertEquals(expectedPaths, actualPaths);
+  }
+
+}

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/predicate/HideInternalContentPathsPredicateTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/predicate/HideInternalContentPathsPredicateTest.java
@@ -22,7 +22,8 @@ package io.wcm.wcm.ui.granite.pathfield.impl.predicate;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,7 @@ class HideInternalContentPathsPredicateTest {
 
   private final AemContext context = new AemContext();
 
-  private Predicate underTest;
+  private Predicate<Resource> underTest;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/util/PredicatedResourceWrapperTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/pathfield/impl/util/PredicatedResourceWrapperTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.apache.commons.collections.Predicate;
 import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.Test;
@@ -93,10 +93,9 @@ class PredicatedResourceWrapperTest {
     assertTrue(children.isEmpty());
   }
 
-  private static final class HideChild2Predcate implements Predicate {
+  private static final class HideChild2Predcate implements Predicate<Resource> {
     @Override
-    public boolean evaluate(Object object) {
-      Resource resource = (Resource)object;
+    public boolean evaluate(Resource resource) {
       return !StringUtils.equals(resource.getName(), "child2");
     }
   }

--- a/src/test/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtilsTest.java
+++ b/src/test/java/io/wcm/wcm/ui/granite/util/impl/PredicateProviderUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.ui.granite.util.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+/**
+ * Unit tests for {@link PredicateProviderUtils}.
+ */
+@ExtendWith(AemContextExtension.class)
+class PredicateProviderUtilsTest {
+
+  private final AemContext context = new AemContext();
+
+  @Test
+  @SuppressWarnings("null")
+  void testToPredicatesWithNullFilter() {
+    List<Predicate<Resource>> result = PredicateProviderUtils.toPredicates(null, context.bundleContext());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testToPredicatesWithEmptyFilter() {
+    String[] emptyFilter = new String[0];
+    List<Predicate<Resource>> result = PredicateProviderUtils.toPredicates(emptyFilter, context.bundleContext());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+}


### PR DESCRIPTION
* Auto-detect latest implementation of PredicateProvider in package `com.day.cq.commons.predicates.PredicateProvider` or `com.day.cq.commons.predicate.PredicateProvider` to avoid warnings in AEMaaCS.
* Get rid of dependency to Commons Collection 3 by using reflection to access the legacy PredicateProvider
* Add special handling for the new dumb implementation of node predicates in package `com.day.cq.commons.predicates` - convert resource to node explicitly before calling them