### PR TITLE
Fix validation issue for hidden mandatory fields in wcmio show/hide handler

### DIFF
--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -132,7 +132,9 @@
     if (show) {
       $element.removeClass("hide");
       $element.removeClass("wcmio-dialog-showhide-status-hide");
-      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=false]")
+      // Only restore validation for fields that had it before being hidden
+      // Look for fields with data-was-* attributes instead of current validation attributes
+      $element.find("[data-was-validation], [data-was-foundation-validation], [data-was-aria-required], [data-was-required]")
           .filter(":not(.hide>input)")
           .filter(":not(input.hide)")
           .filter(":not(.hide>textarea)")
@@ -144,7 +146,7 @@
           });
     } else {
       $element.addClass("hide");
-      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=true]")
+      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [aria-required=true], [required]")
           .each(function (index, field) {
             toggleValidation($(field), false);
           });


### PR DESCRIPTION
## Problem
Hidden mandatory fields were incorrectly triggering validation, preventing dialog saves even when all visible required fields were properly filled.

## Solution
Fixed the field selector logic in `setVisibilityAndHandleFieldValidation` function to only restore validation for fields that had it before being hidden.

## Changes Made

### 1. Fixed "show" selector for validation restoration
**Before:**

`$element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=false]")`

**After:**

`$element.find("[data-was-validation], [data-was-foundation-validation], [data-was-aria-required], [data-was-required]")`

**Reason:**

- Removed incorrect `[aria-required=false]` selector that was enabling validation on non-required fields
- Changed to only look for temporary stored attributes `(data-was-*)` to ensure we only restore validation that was previously disabled
- Added `[data-was-required]` to handle HTML5 required attribute


### 2. Enhanced "hide" selector
**Before:**

`$element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required=true]")`

**After:**

`$element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [aria-required=true], [required]"`)

**Reason:** Added `[required]` to ensure HTML5 required attributes are also handled when hiding fields.


### Testing Performed

-  Tested with single show/hide groups containing mandatory fields
-  Tested with multiple nested show/hide scenarios
-  Tested with coral-multifield components
-  Verified dialog saves when all visible required fields are filled
-  Verified hidden fields don't trigger validation
-  Tested with mixed required and optional fields


### Fixes #54 