### PR TITLE
Make sure hidden fields are not being posted, when they are in a hidden piece of a dialog.

### DIFF
--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -157,33 +157,33 @@
   }
 
   function toggleHiddenInput($element, show) {
-      if (show) {
-          $element.find("input:hidden[data-was-hidden]")
-              .each(function (index, field) {
-                  var $field = $(field);
-                  $field.removeAttr("data-was-hidden");
-                  $field.removeAttr("disabled");
-              });
-          if ($element.attr("type") === "hidden" && $element.attr("data-was-hidden") !== undefined) {
-              $element.removeAttr("data-was-hidden");
-              $element.removeAttr("disabled");
-          }
-      } else {
-          $element.find("input:hidden")
-              .filter(":not([data-was-hidden])")
-              .filter(":not([disabled])")
-              .filter(":not([name$='@Delete'])")
-              .each(function (index, field) {
-                  var $field = $(field);
-                  $field.attr("data-was-hidden", true);
-                  $field.attr("disabled", true);
-              });
-          if ($element.attr("type") === "hidden" && $element.attr("disabled") === undefined &&
-              $element.attr("name") !== undefined && !$element.attr("name").endsWith("@Delete")) {
-              $element.attr("data-was-hidden", true);
-              $element.attr("disabled", true);
-          }
+    if (show) {
+      $element.find("input:hidden[data-was-hidden]")
+        .each(function (index, field) {
+          var $field = $(field);
+          $field.removeAttr("data-was-hidden");
+          $field.removeAttr("disabled");
+        });
+      if ($element.attr("type") === "hidden" && $element.attr("data-was-hidden") !== undefined) {
+        $element.removeAttr("data-was-hidden");
+        $element.removeAttr("disabled");
       }
+    } else {
+      $element.find("input:hidden")
+        .filter(":not([data-was-hidden])")
+        .filter(":not([disabled])")
+        .filter(":not([name$='@Delete'])")
+        .each(function (index, field) {
+          var $field = $(field);
+          $field.attr("data-was-hidden", true);
+          $field.attr("disabled", true);
+        });
+      if ($element.attr("type") === "hidden" && $element.attr("disabled") === undefined &&
+        $element.attr("name") !== undefined && !$element.attr("name").endsWith("@Delete")) {
+        $element.attr("data-was-hidden", true);
+        $element.attr("disabled", true);
+      }
+    }
   }
 
   /**

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -129,6 +129,8 @@
       $element = $element.add($('#' + $parent.parent().attr('aria-labelledby')));
     }
 
+    toggleHiddenInput($element, show);
+
     if (show) {
       $element.removeClass("hide");
       $element.removeClass("wcmio-dialog-showhide-status-hide");
@@ -152,8 +154,6 @@
           });
       $element.addClass("wcmio-dialog-showhide-status-hide");
     }
-
-    toggleHiddenInput($element, show);
   }
 
   function toggleHiddenInput($element, show) {
@@ -172,12 +172,14 @@
           $element.find("input:hidden")
               .filter(":not([data-was-hidden])")
               .filter(":not([disabled])")
+              .filter(":not([name$='@Delete'])")
               .each(function (index, field) {
                   var $field = $(field);
                   $field.attr("data-was-hidden", true);
                   $field.attr("disabled", true);
               });
-          if ($element.attr("type") === "hidden" && $element.attr("disabled") === undefined) {
+          if ($element.attr("type") === "hidden" && $element.attr("disabled") === undefined &&
+              $element.attr("name") !== undefined && !$element.attr("name").endsWith("@Delete")) {
               $element.attr("data-was-hidden", true);
               $element.attr("disabled", true);
           }

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -152,6 +152,36 @@
           });
       $element.addClass("wcmio-dialog-showhide-status-hide");
     }
+
+    toggleHiddenInput($element, show);
+  }
+
+  function toggleHiddenInput($element, show) {
+      if (show) {
+          $element.find("input:hidden[data-was-hidden]")
+              .each(function (index, field) {
+                  var $field = $(field);
+                  $field.removeAttr("data-was-hidden");
+                  $field.removeAttr("disabled");
+              });
+          if ($element.attr("type") === "hidden" && $element.attr("data-was-hidden") !== undefined) {
+              $element.removeAttr("data-was-hidden");
+              $element.removeAttr("disabled");
+          }
+      } else {
+          $element.find("input:hidden")
+              .filter(":not([data-was-hidden])")
+              .filter(":not([disabled])")
+              .each(function (index, field) {
+                  var $field = $(field);
+                  $field.attr("data-was-hidden", true);
+                  $field.attr("disabled", true);
+              });
+          if ($element.attr("type") === "hidden" && $element.attr("disabled") === undefined) {
+              $element.attr("data-was-hidden", true);
+              $element.attr("disabled", true);
+          }
+      }
   }
 
   /**

--- a/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
@@ -391,15 +391,17 @@ describe('dialog-showhide', () => {
         let hiddenElement1;
         let hiddenElement2;
         let hiddenElement3;
+        let hiddenElement3Delete;
         beforeEach(() => {
             document.body.innerHTML = `
             <div id="dialog">
                 <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".checkbox-target">
                     <input type="checkbox" value="true"/>
                 </coral-checkbox>
-                <div class="checkbox-target" id="checkbox-target-1" data-showhidetargetvalue="true"><input id="input-1" type="hidden" value="value-1"/></div>
-                <div class="checkbox-target" id="checkbox-target-2" data-showhidetargetvalue="true" data-showhidetargetnot="true"><input id="input-2" type="hidden" value="value-2"/></div>
-                <input class="checkbox-target" id="input-3" type="hidden" value="value-3" data-showhidetargetvalue="true"/>
+                <div class="checkbox-target" id="checkbox-target-1" data-showhidetargetvalue="true"><input id="input-1" name="hidden-1" type="hidden" value="value-1"/></div>
+                <div class="checkbox-target" id="checkbox-target-2" data-showhidetargetvalue="true" data-showhidetargetnot="true"><input id="input-2" type="hidden" name="hidden-2" value="value-2"/></div>
+                <input class="checkbox-target" id="input-3" name="hidden-3" type="hidden" value="value-3" data-showhidetargetvalue="true"/>
+                <input class="checkbox-target" id="input-3-delete" name="hidden-3@Delete" type="hidden" data-showhidetargetvalue="true"/>
             </div>
             `;
             checkbox = document.querySelector('coral-checkbox');
@@ -407,6 +409,7 @@ describe('dialog-showhide', () => {
             hiddenElement1 = document.querySelector('#input-1');
             hiddenElement2 = document.querySelector('#input-2');
             hiddenElement3 = document.querySelector('#input-3');
+            hiddenElement3Delete = document.querySelector('#input-3-delete');
         });
 
         it('Load', () => {
@@ -416,6 +419,7 @@ describe('dialog-showhide', () => {
             expect(hiddenElement1).toBeDisabled();
             expect(hiddenElement2).not.toBeDisabled();
             expect(hiddenElement3).toBeDisabled();
+            expect(hiddenElement3Delete).not.toBeDisabled();
         });
 
         it('Change', () => {
@@ -426,6 +430,7 @@ describe('dialog-showhide', () => {
             expect(hiddenElement1).not.toBeDisabled();
             expect(hiddenElement2).toBeDisabled();
             expect(hiddenElement3).not.toBeDisabled();
+            expect(hiddenElement3Delete).not.toBeDisabled();
         });
     });
 });

--- a/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
@@ -385,4 +385,47 @@ describe('dialog-showhide', () => {
             expect(radioTargetElement2).toBeHidden();
         });
     });
+
+    describe('Hidden input', () => {
+        let checkbox;
+        let hiddenElement1;
+        let hiddenElement2;
+        let hiddenElement3;
+        beforeEach(() => {
+            document.body.innerHTML = `
+            <div id="dialog">
+                <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".checkbox-target">
+                    <input type="checkbox" value="true"/>
+                </coral-checkbox>
+                <div class="checkbox-target" id="checkbox-target-1" data-showhidetargetvalue="true"><input id="input-1" type="hidden" value="value-1"/></div>
+                <div class="checkbox-target" id="checkbox-target-2" data-showhidetargetvalue="true" data-showhidetargetnot="true"><input id="input-2" type="hidden" value="value-2"/></div>
+                <input class="checkbox-target" id="input-3" type="hidden" value="value-3" data-showhidetargetvalue="true"/>
+            </div>
+            `;
+            checkbox = document.querySelector('coral-checkbox');
+            checkbox.value = 'true';
+            hiddenElement1 = document.querySelector('#input-1');
+            hiddenElement2 = document.querySelector('#input-2');
+            hiddenElement3 = document.querySelector('#input-3');
+        });
+
+        it('Load', () => {
+            checkbox.checked = false;
+            checkbox.querySelector('input').checked = false;
+            triggerContentLoaded();
+            expect(hiddenElement1).toBeDisabled();
+            expect(hiddenElement2).not.toBeDisabled();
+            expect(hiddenElement3).toBeDisabled();
+        });
+
+        it('Change', () => {
+            triggerContentLoaded();
+            checkbox.checked = true;
+            checkbox.querySelector('input').checked = true;
+            $(checkbox).trigger('change');
+            expect(hiddenElement1).not.toBeDisabled();
+            expect(hiddenElement2).toBeDisabled();
+            expect(hiddenElement3).not.toBeDisabled();
+        });
+    });
 });


### PR DESCRIPTION
With this feature, we will disable hidden input fields that are part of the _hidden_ parts of a dialog.

This ensures that we only post those fields to the repository when they are part of a visible part of the dialog. If we don't to this and two hidden fields have the same name and a different value, they will be both stored in a single field as an array property with two values.
