### PR TITLE
wcmio-dialog-showhide: Ensure nested Show/Hide blocks do not conflict with each other

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
       <action type="fix" dev="rubnig" issue="59">
         Granite UI Show/Hide: Make sure hidden fields are not being posted, when they are in a hidden piece of a dialog.
       </action>
+      <action type="fix" dev="sseifert" issue="60">
+        Granite UI Show/Hide: Ensure nested Show/Hide blocks do not conflict with each other.
+      </action>
     </release>
 
     <release version="1.11.4" date="2025-09-22">

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -60,6 +60,10 @@
       return;
     }
 
+    // Check if this show/hide handler is itself within a hidden context
+    // If so, all its targets should be treated as hidden regardless of its own logic
+    var isHandlerHidden = $element.closest('.hide.wcmio-dialog-showhide-status-hide').length > 0;
+
     // optional: get the selector to find the comment parent element
     var parentSelector = $element.data("wcmioDialogShowhideParent");
 
@@ -103,6 +107,12 @@
           || includesCommaSeparated(element.dataset.showhidetargetvalues, values));
       var not = element.dataset.showhidetargetnot === 'true';
       var show = element && targetValueIsContained !== not;
+      
+      // If the handler itself is hidden, force all targets to be hidden
+      if (isHandlerHidden) {
+        show = false;
+      }
+      
       setVisibilityAndHandleFieldValidation($(element), show);
     });
   }
@@ -154,6 +164,13 @@
           });
       $element.addClass("wcmio-dialog-showhide-status-hide");
     }
+
+    // Trigger re-evaluation of nested show/hide handlers when context visibility changes
+    $element.find('.wcmio-dialog-showhide').each(function() {
+      var $nestedHandler = $(this);
+      var nestedComponent = $nestedHandler[0];
+      showHide(nestedComponent, nestedComponent);
+    });
   }
 
   function toggleHiddenInput($element, show) {

--- a/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
+++ b/src/main/webapp/app-root/clientlibs/io.wcm.ui.granite.showhidedialogfields/js/showhide.js
@@ -134,7 +134,7 @@
     if (show) {
       $element.removeClass("hide");
       $element.removeClass("wcmio-dialog-showhide-status-hide");
-      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required], [data-was-aria-required], foundation-autocomplete")
+      filterElementsExcludingNestedShowHide($element, "[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required], [data-was-aria-required], foundation-autocomplete")
           .filter(":not(input[role=combobox])") // Input belonging to foundation-autocomplete
           .filter(":not(.hide>input)")
           .filter(":not(input.hide)")
@@ -147,7 +147,7 @@
           });
     } else {
       $element.addClass("hide");
-      $element.find("[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required], [data-was-aria-required], foundation-autocomplete")
+      filterElementsExcludingNestedShowHide($element, "[data-validation]:not([data-validation='']), [data-foundation-validation]:not([data-foundation-validation='']), [data-was-validation], [data-was-foundation-validation], [aria-required], [data-was-aria-required], foundation-autocomplete")
           .filter(":not(input[role=combobox])") // Input belonging to foundation-autocomplete
           .each(function (index, field) {
             toggleValidation($(field), false);
@@ -158,7 +158,7 @@
 
   function toggleHiddenInput($element, show) {
     if (show) {
-      $element.find("input:hidden[data-was-hidden]")
+      filterElementsExcludingNestedShowHide($element, "input:hidden[data-was-hidden]")
         .each(function (index, field) {
           var $field = $(field);
           $field.removeAttr("data-was-hidden");
@@ -169,7 +169,7 @@
         $element.removeAttr("disabled");
       }
     } else {
-      $element.find("input:hidden")
+      filterElementsExcludingNestedShowHide($element, "input:hidden")
         .filter(":not([data-was-hidden])")
         .filter(":not([disabled])")
         .filter(":not([name$='@Delete'])")
@@ -231,6 +231,55 @@
       api.checkValidity();
       api.updateUI();
     }
+  }
+
+  /**
+   * Filters elements within the given parent element, excluding those that belong to nested show/hide handlers.
+   * This prevents conflicts when show/hide handlers are nested inside each other.
+   *
+   * @param {jQuery} $parent Parent element to search within.
+   * @param {String} selector CSS selector to find elements.
+   * @returns {jQuery} Filtered jQuery object containing only elements not controlled by nested handlers.
+   */
+  function filterElementsExcludingNestedShowHide($parent, selector) {
+    var $allElements = $parent.find(selector);
+    var $filteredElements = $();
+
+    // Find all nested show/hide control elements within the parent
+    var $nestedShowHideElements = $parent.find('.wcmio-dialog-showhide');
+
+    $allElements.each(function() {
+      var $element = $(this);
+      var belongsToNestedHandler = false;
+
+      // Check if this element is controlled by any nested show/hide handler
+      $nestedShowHideElements.each(function() {
+        var $nestedControl = $(this);
+        var nestedTarget = $nestedControl.data("wcmioDialogShowhideTarget");
+        
+        if (nestedTarget) {
+          // Check if the element is within the scope of this nested handler's target
+          var $nestedTargets = $(nestedTarget);
+          $nestedTargets.each(function() {
+            if ($(this).find($element).length > 0 || $(this).is($element)) {
+              belongsToNestedHandler = true;
+              return false; // Break out of loop
+            }
+          });
+          
+          if (belongsToNestedHandler) {
+            return false; // Break out of outer loop
+          }
+        }
+      });
+
+      // Only include elements that don't belong to nested handlers
+      if (!belongsToNestedHandler) {
+        $filteredElements = $filteredElements.add($element);
+      }
+    });
+
+    return $filteredElements;
   }
 
 })(document, Granite.$);

--- a/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
@@ -433,4 +433,152 @@ describe('dialog-showhide', () => {
             expect(hiddenElement3Delete).not.toBeDisabled();
         });
     });
+
+    describe('Nested Show/Hide Handlers', () => {
+        describe('Basic nested functionality', () => {
+            it('Should handle nested show/hide handlers without validation conflicts', () => {
+                document.body.innerHTML = `
+                <div id="dialog">
+                    <!-- Outer handler -->
+                    <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".outer-target">
+                        <input type="checkbox" value="true"/>
+                    </coral-checkbox>
+                    
+                    <div class="outer-target" data-showhidetargetvalue="true">
+                        <input id="outer-input" type="text" aria-required="true" data-foundation-validation="simple-attribute" data-simple-attribute="true"/>
+                        
+                        <!-- Inner nested handler -->
+                        <coral-checkbox class="wcmio-dialog-showhide inner-checkbox" data-wcmio-dialog-showhide-target=".inner-target">
+                            <input type="checkbox" value="true"/>
+                        </coral-checkbox>
+                        
+                        <div class="inner-target" data-showhidetargetvalue="true">
+                            <input id="inner-input" type="text" aria-required="true" data-foundation-validation="simple-attribute" data-simple-attribute="true"/>
+                        </div>
+                        
+                        <!-- Sibling input that should only be controlled by outer handler -->
+                        <input id="sibling-input" type="text" aria-required="true" data-foundation-validation="simple-attribute" data-simple-attribute="true"/>
+                    </div>
+                </div>`;
+                
+                const outerCheckbox = document.querySelector('coral-checkbox:not(.inner-checkbox)');
+                const innerCheckbox = document.querySelector('.inner-checkbox');
+                const outerInput = document.querySelector('#outer-input');
+                const innerInput = document.querySelector('#inner-input');
+                const siblingInput = document.querySelector('#sibling-input');
+                
+                // Test initial state - both checkboxes unchecked
+                outerCheckbox.checked = false;
+                outerCheckbox.value = 'true';
+                innerCheckbox.checked = false;  
+                innerCheckbox.value = 'true';
+                
+                triggerContentLoaded();
+                
+                // Outer target should be hidden, so all inputs should be non-required
+                expect(document.querySelector('.outer-target')).toBeHidden();
+                expect(outerInput).not.toBeRequired();
+                expect(innerInput).not.toBeRequired();
+                expect(siblingInput).not.toBeRequired();
+                
+                // Show outer target
+                outerCheckbox.checked = true;
+                $(outerCheckbox).trigger('change');
+                
+                // Now outer and sibling inputs should be required, but inner should still be hidden
+                expect(document.querySelector('.outer-target')).not.toBeHidden();
+                expect(outerInput).toBeRequired(); // Controlled by outer handler
+                expect(siblingInput).toBeRequired(); // Controlled by outer handler
+                expect(document.querySelector('.inner-target')).toBeHidden();
+                expect(innerInput).not.toBeRequired(); // Controlled by inner handler, still hidden
+                
+                // Show inner target
+                innerCheckbox.checked = true;
+                $(innerCheckbox).trigger('change');
+                
+                // All inputs should now be required
+                expect(document.querySelector('.inner-target')).not.toBeHidden();
+                expect(outerInput).toBeRequired(); // Still controlled by outer
+                expect(siblingInput).toBeRequired(); // Still controlled by outer  
+                expect(innerInput).toBeRequired(); // Now controlled by inner
+                
+                // Hide inner target - should not affect outer controlled inputs
+                innerCheckbox.checked = false;
+                $(innerCheckbox).trigger('change');
+                
+                expect(document.querySelector('.inner-target')).toBeHidden();
+                expect(outerInput).toBeRequired(); // Should remain unchanged
+                expect(siblingInput).toBeRequired(); // Should remain unchanged
+                expect(innerInput).not.toBeRequired(); // Controlled by inner handler
+            });
+
+            it('Should handle nested hidden inputs without conflicts', () => {
+                document.body.innerHTML = `
+                <div id="dialog">
+                    <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".outer-target">
+                        <input type="checkbox" value="true"/>
+                    </coral-checkbox>
+                    
+                    <div class="outer-target" data-showhidetargetvalue="true">
+                        <input id="outer-hidden" type="hidden" name="outer-field" value="outer-value"/>
+                        
+                        <coral-checkbox class="wcmio-dialog-showhide inner-checkbox" data-wcmio-dialog-showhide-target=".inner-target">
+                            <input type="checkbox" value="true"/>
+                        </coral-checkbox>
+                        
+                        <div class="inner-target" data-showhidetargetvalue="true">
+                            <input id="inner-hidden" type="hidden" name="inner-field" value="inner-value"/>
+                        </div>
+                        
+                        <input id="sibling-hidden" type="hidden" name="sibling-field" value="sibling-value"/>
+                    </div>
+                </div>`;
+                
+                const outerCheckbox = document.querySelector('coral-checkbox:not(.inner-checkbox)');
+                const innerCheckbox = document.querySelector('.inner-checkbox');
+                const outerHidden = document.querySelector('#outer-hidden');
+                const innerHidden = document.querySelector('#inner-hidden');
+                const siblingHidden = document.querySelector('#sibling-hidden');
+                
+                // Both checkboxes unchecked
+                outerCheckbox.checked = false;
+                outerCheckbox.value = 'true';
+                innerCheckbox.checked = false;
+                innerCheckbox.value = 'true';
+                
+                triggerContentLoaded();
+                
+                // All hidden inputs should be disabled because outer target is hidden
+                expect(outerHidden).toBeDisabled();
+                expect(innerHidden).toBeDisabled();
+                expect(siblingHidden).toBeDisabled();
+                
+                // Show outer target
+                outerCheckbox.checked = true;
+                $(outerCheckbox).trigger('change');
+                
+                // Outer controlled inputs should be enabled, inner should still be disabled
+                expect(outerHidden).not.toBeDisabled();
+                expect(siblingHidden).not.toBeDisabled();
+                expect(innerHidden).toBeDisabled(); // Still controlled by inner handler
+                
+                // Show inner target
+                innerCheckbox.checked = true;
+                $(innerCheckbox).trigger('change');
+                
+                // All should be enabled
+                expect(outerHidden).not.toBeDisabled();
+                expect(siblingHidden).not.toBeDisabled();
+                expect(innerHidden).not.toBeDisabled();
+                
+                // Hide inner target - should not affect outer controlled inputs
+                innerCheckbox.checked = false;
+                $(innerCheckbox).trigger('change');
+                
+                expect(outerHidden).not.toBeDisabled(); // Should remain unchanged
+                expect(siblingHidden).not.toBeDisabled(); // Should remain unchanged
+                expect(innerHidden).toBeDisabled(); // Controlled by inner handler
+            });
+        });
+    });
 });

--- a/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
+++ b/src/test/javascript/io.wcm.ui.granite.showhidedialogfields/showhide.test.js
@@ -558,6 +558,67 @@ describe('dialog-showhide', () => {
                 expect(siblingHidden).not.toBeDisabled(); // Should remain unchanged
                 expect(innerHidden).toBeDisabled(); // Controlled by inner handler
             });
+
+            it('Should disable nested handler validation when parent context is hidden', () => {
+                document.body.innerHTML = `
+                <div id="dialog">
+                    <!-- Outer handler that controls parent context -->
+                    <coral-checkbox class="wcmio-dialog-showhide" data-wcmio-dialog-showhide-target=".parent-context">
+                        <input type="checkbox" value="true"/>
+                    </coral-checkbox>
+                    
+                    <div class="parent-context" data-showhidetargetvalue="true">
+                        <!-- Nested handler inside parent context -->
+                        <coral-checkbox class="wcmio-dialog-showhide nested-handler" data-wcmio-dialog-showhide-target=".nested-target">
+                            <input type="checkbox" value="true"/>
+                        </coral-checkbox>
+                        
+                        <div class="nested-target" data-showhidetargetvalue="true">
+                            <input id="nested-required-input" type="text" aria-required="true" data-foundation-validation="simple-attribute" data-simple-attribute="true"/>
+                        </div>
+                    </div>
+                </div>`;
+                
+                const outerCheckbox = document.querySelector('coral-checkbox:not(.nested-handler)');
+                const nestedCheckbox = document.querySelector('.nested-handler');
+                const nestedInput = document.querySelector('#nested-required-input');
+                
+                // Start with outer unchecked (parent context hidden) and nested checked
+                outerCheckbox.checked = false;
+                outerCheckbox.value = 'true';
+                nestedCheckbox.checked = true; // This would normally show the nested target
+                nestedCheckbox.value = 'true';
+                
+                triggerContentLoaded();
+                
+                // Parent context should be hidden
+                expect(document.querySelector('.parent-context')).toBeHidden();
+                
+                // Even though nested checkbox is checked, the nested target should be hidden 
+                // because the nested handler recognizes it's in a hidden context
+                expect(document.querySelector('.nested-target')).toBeHidden();
+                expect(nestedInput).not.toBeRequired(); // Should not be required because context is hidden
+                
+                // Now show the parent context
+                outerCheckbox.checked = true;
+                $(outerCheckbox).trigger('change');
+                
+                expect(document.querySelector('.parent-context')).not.toBeHidden();
+                
+                // The nested handler should now work normally, and since nested checkbox is checked,
+                // the nested target should be shown
+                expect(document.querySelector('.nested-target')).not.toBeHidden();
+                expect(nestedInput).toBeRequired(); // Should now be required
+                
+                // Hide parent context again
+                outerCheckbox.checked = false;
+                $(outerCheckbox).trigger('change');
+                
+                expect(document.querySelector('.parent-context')).toBeHidden();
+                // Nested target should be hidden again regardless of nested checkbox state
+                expect(document.querySelector('.nested-target')).toBeHidden();
+                expect(nestedInput).not.toBeRequired();
+            });
         });
     });
 });


### PR DESCRIPTION
Fixes #60

the root cause of #60 was, that nested show/hide blocks conflicted each other. when you switch the outer select box to show the nested show/hide block, the JS functionality for that works correct, showing the correct fields and hiding and disabling validation for the other fields. but then the JS code of the outer show/hide blocks goes along and enables the hidden stuff again. so we need to make sure the outer show/hide block does not meddle with fields in control of nested show/hide blocks.